### PR TITLE
Add streamlit diet planner skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # Diet Planner
 
-This repository contains planning notes for a simple web application that helps determine daily calorie and macronutrient needs.
+A minimal Streamlit application that calculates daily calorie and macronutrient
+targets and stores them in Supabase.
 
-See [PLAN.md](./PLAN.md) for the full overview of the proposed MVP using Streamlit and Supabase.
+## Setup
 
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide Supabase credentials via environment variables:
+   ```bash
+   export SUPABASE_URL=YOUR_SUPABASE_URL
+   export SUPABASE_KEY=YOUR_SERVICE_ROLE_KEY
+   ```
+3. Run the application:
+   ```bash
+   streamlit run app.py
+   ```
+
+See [PLAN.md](./PLAN.md) for the design overview.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+"""Streamlit interface for the diet planner."""
+import streamlit as st
+from calculator import UserInput, calculate_macros
+from supabase_client import save_results
+
+st.title("Diet Planner")
+
+with st.form("inputs"):
+    gender = st.selectbox("Gender", ["Male", "Female"])
+    age = st.number_input("Age", min_value=0, value=25)
+    weight = st.number_input("Weight (kg)", min_value=0.0, value=70.0, step=0.1)
+    height = st.number_input("Height (cm)", min_value=0.0, value=170.0, step=0.1)
+    activity = st.number_input("Activity Factor", min_value=1.0, value=1.2)
+    fat_ratio = st.number_input("Fat Portion (0-1)", min_value=0.0, max_value=1.0, value=0.3)
+    protein_per_kg = st.number_input("Protein (g/kg)", min_value=0.0, value=1.5)
+    submitted = st.form_submit_button("Calculate")
+
+if submitted:
+    user = UserInput(
+        gender=gender,
+        age=int(age),
+        weight=float(weight),
+        height=float(height),
+        activity_factor=float(activity),
+        fat_ratio=float(fat_ratio),
+        protein_per_kg=float(protein_per_kg),
+    )
+    result = calculate_macros(user)
+
+    st.subheader("Results")
+    st.write(f"Total Calories: {result.total_calories}")
+    st.write(
+        f"Carbs: {result.cho.grams} g ({result.cho.calories} kcal)")
+    st.write(
+        f"Fat: {result.fat.grams} g ({result.fat.calories} kcal)")
+    st.write(
+        f"Protein: {result.ptn.grams} g ({result.ptn.calories} kcal)")
+
+    save_results(
+        {
+            "gender": gender,
+            "age": int(age),
+            "weight": float(weight),
+            "height": float(height),
+            "activity_factor": float(activity),
+            "fat_ratio": float(fat_ratio),
+            "protein_per_kg": float(protein_per_kg),
+            "total_calories": result.total_calories,
+            "cho_calories": result.cho.calories,
+            "cho_grams": result.cho.grams,
+            "fat_calories": result.fat.calories,
+            "fat_grams": result.fat.grams,
+            "ptn_calories": result.ptn.calories,
+            "ptn_grams": result.ptn.grams,
+        }
+    )
+    st.success("Results saved to Supabase")

--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,59 @@
+"""Macronutrient and calorie calculations."""
+from dataclasses import dataclass
+
+@dataclass
+class UserInput:
+    gender: str
+    age: int
+    weight: float  # kg
+    height: float  # cm
+    activity_factor: float
+    fat_ratio: float  # portion of calories from fat, e.g. 0.3
+    protein_per_kg: float  # grams of protein per kg body weight
+
+@dataclass
+class MacroResult:
+    calories: float
+    grams: float
+
+@dataclass
+class CalculationResult:
+    cho: MacroResult
+    fat: MacroResult
+    ptn: MacroResult
+    total_calories: float
+
+
+def calculate_bmr(user: UserInput) -> float:
+    """Calculate basal metabolic rate using Mifflin-St Jeor formula."""
+    if user.gender.lower() == "male":
+        s = 5
+    else:
+        s = -161
+    return 10 * user.weight + 6.25 * user.height - 5 * user.age + s
+
+
+def calculate_tdee(user: UserInput) -> float:
+    """Calculate total daily energy expenditure."""
+    bmr = calculate_bmr(user)
+    return bmr * user.activity_factor
+
+
+def calculate_macros(user: UserInput) -> CalculationResult:
+    """Calculate macronutrients based on user input."""
+    total_cal = calculate_tdee(user)
+    protein_g = user.weight * user.protein_per_kg
+    protein_cal = protein_g * 4
+
+    fat_cal = total_cal * user.fat_ratio
+    fat_g = fat_cal / 9
+
+    cho_cal = total_cal - protein_cal - fat_cal
+    cho_g = cho_cal / 4
+
+    return CalculationResult(
+        cho=MacroResult(calories=round(cho_cal, 2), grams=round(cho_g, 2)),
+        fat=MacroResult(calories=round(fat_cal, 2), grams=round(fat_g, 2)),
+        ptn=MacroResult(calories=round(protein_cal, 2), grams=round(protein_g, 2)),
+        total_calories=round(total_cal, 2),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+supabase

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -1,0 +1,25 @@
+"""Minimal wrapper around Supabase client."""
+import os
+from typing import Any, Dict
+
+try:
+    from supabase import create_client, Client  # type: ignore
+except ImportError:  # pragma: no cover - library not installed in tests
+    Client = Any  # type: ignore
+    def create_client(*args: str, **kwargs: str) -> Any:
+        raise RuntimeError(
+            "supabase-py package is required to use Supabase features")
+
+
+def get_client() -> Client:
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("SUPABASE_URL and SUPABASE_KEY must be set")
+    return create_client(url, key)
+
+
+def save_results(data: Dict[str, Any]) -> None:
+    """Store calculation results in Supabase table `calculations`."""
+    client = get_client()
+    client.table("calculations").insert(data).execute()

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,23 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from calculator import UserInput, calculate_macros
+
+
+def test_calculate_macros():
+    user = UserInput(
+        gender="Male",
+        age=29,
+        weight=110,
+        height=176,
+        activity_factor=1.2,
+        fat_ratio=0.3,
+        protein_per_kg=1.5,
+    )
+    result = calculate_macros(user)
+    assert round(result.total_calories) == 2472
+    assert round(result.cho.calories) == 1070
+    assert round(result.fat.calories) == 742
+    assert round(result.ptn.calories) == 660
+    assert round(result.cho.grams) == 268
+    assert round(result.fat.grams) == 82
+    assert round(result.ptn.grams) == 165


### PR DESCRIPTION
## Summary
- implement calorie/macro calculation functions
- create Streamlit UI to collect user input and store results in Supabase
- add minimal Supabase client wrapper
- document setup instructions
- include basic unit test for macro calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684778383c1c832c837b54dd083fba82